### PR TITLE
Fix: closing bracket missing in cli.py

### DIFF
--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -126,7 +126,7 @@ class _HumanReadableFormatter(object):
         self._stream.flush()
 
     def print_lcd_timeout(self, value):
-        self._print_simple('Default timeout:\t%02u' % (value['default'])
+        self._print_simple('Default timeout:\t%02u' % (value['default']))
         self._print_simple('Timeout in progress:\t%02u' % (value['current']))
 
     def print_days(self, value):


### PR DESCRIPTION
```
File "/usr/local/lib/python3.5/dist-packages/cometblue/cli.py", line 130
    self._print_simple('Timeout in progress:\t%02u' % (value['current']))
       ^
SyntaxError: invalid syntax
```